### PR TITLE
feat(content): Restrict massive human shield generator availability to after introduction of their carriers

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -8,8 +8,6 @@ outfitter "Kraz Advanced"
 	"Plasma Howitzer"
 	"D67-TM Shield Generator"
 	"D94-YV Shield Generator"
-	"F148-QT Shield Generator"
-	"F215-BU Shield Generator"
 	"Compressed Fuel Pod"
 	"Marksman Anti-Missile"
 	"Sniper Anti-Missile"
@@ -25,6 +23,19 @@ mission "Plasma Repeater Turret Available"
 event "plasma repeater turret"
 	outfitter "Kraz Advanced"
 		"Plasma Repeater Turret"
+
+mission "Massive Human Shield Generators Available"
+	landing
+	invisible
+	to offer
+		has "event: southern carriers 1"
+	on offer
+		event "massive human shield generators available" 90
+
+event "massive human shield generators available"
+	outfitter "Kraz Advanced"
+		"F148-QT Shield Generator"
+		"F215-BU Shield Generator"
 
 outfitter "Lovelace Basics"
 	"R0152 Naval Shield"


### PR DESCRIPTION
It doesn't make sense that the F215-BU Shield Generator references the Skein when it isn't available at the start of the game. This moves that generator, as well as the F148-QT, to an event that will fire alongside `southern carriers 2`, which is the same event that introduces the Skein.