### PR TITLE
fix(content): Plasma Repeater Turret will unlock correctly

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -16,7 +16,7 @@ mission "Plasma Repeater Turret Available"
 	landing
 	invisible
 	to offer
-		has "event: plasma repeater basics"
+		has "event: plasma repeater advanced"
 	on offer
 		event "plasma repeater turret" 30
 		


### PR DESCRIPTION
I borked this with one of my PRs in main by removing the event "plasma repeater basics". So this updates the repeater turret to unlock 30 days after "plasma repeater advanced".